### PR TITLE
 DB設計の見直し 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ migrate:
 	docker compose run --rm migrate
 	
 psql:
-	docker compose exec postgres psql mydb
+	docker compose exec postgres psql ${POSTGRES_DB}
 
 exec:
 	docker compose exec postgres sh


### PR DESCRIPTION
Closes [ DB設計の見直し #22 ](https://github.com/senntou/oshi-project/issues/22)

# Why
* コンテンツの情報をどう管理するか
  * start_date
  * end_date
  * year
  * season
* content_dateの履歴管理
  * 論理削除では、データが膨らんだときに困る？
  * 履歴テーブルを作成する
* appearing_contentテーブルの履歴管理
  * content_dateと同様
  * updateも存在する 
  
# What
コンテンツ情報は上記の内容で決定
履歴管理は`action_log`テーブルにより管理